### PR TITLE
Fix mobile menu not working when opened

### DIFF
--- a/style.css
+++ b/style.css
@@ -1274,7 +1274,7 @@ ul.nav.activello-mobile-menu li.menu-item-has-children > ul.dropdown-menu.active
     .site-navigation-inner .navbar-nav>li {
     	float: none;
     }
-    .navbar-collapse.collapse {
+    .navbar-collapse.collapse:not(.show) {
 	    display: none !important;
 	}
 	.navbar-collapse.collapse.in {


### PR DESCRIPTION
When menu is opened (with class `.show`) on mobile, the `.navbar-collapse.collapse { display: none !important; } ` rule was overriding the `.show`.

With this change, it doesn't override `.navbar-collapse.collapse.show` anymore.